### PR TITLE
MDSKY optimizations; WAD file search added.

### DIFF
--- a/32x.h
+++ b/32x.h
@@ -25,6 +25,8 @@
 #ifndef __32X_H__
 #define __32X_H__
 
+#define MARS_CART_ROM       (*(volatile unsigned char *)0x2000000)
+
 #define MARS_CRAM           (*(volatile unsigned short *)0x20004200)
 #define MARS_FRAMEBUFFER    (*(volatile unsigned short *)0x24000000)
 #define MARS_OVERWRITE_IMG  (*(volatile unsigned short *)0x24020000)

--- a/doomdef.h
+++ b/doomdef.h
@@ -743,11 +743,9 @@ void I_DrawColumn(int dc_x, int dc_yl, int dc_yh, int light, fixed_t dc_iscale,
 	fixed_t dc_texturemid, inpixel_t* dc_source, int dc_texheight);
 
 #ifdef MDSKY
-void I_DrawSkyColumn(int dc_x, int dc_yl, int dc_yh, int light, fixed_t dc_iscale,
-	fixed_t dc_texturemid, inpixel_t* dc_source, int dc_texheight);
+void I_DrawSkyColumn(int dc_x, int dc_yl, int dc_yh);
 
-void I_DrawSkyColumnLow(int dc_x, int dc_yl, int dc_yh, int light, fixed_t dc_iscale,
-	fixed_t dc_texturemid, inpixel_t* dc_source, int dc_texheight);
+void I_DrawSkyColumnLow(int dc_x, int dc_yl, int dc_yh);
 #endif
 
 void I_DrawColumnNPo2(int dc_x, int dc_yl, int dc_yh, int light, fixed_t dc_iscale,

--- a/r_local.h
+++ b/r_local.h
@@ -270,6 +270,7 @@ void	R_SetupLevel(void);
 void	R_SetupTextureCaches(void);
 
 typedef void (*drawcol_t)(int, int, int, int, fixed_t, fixed_t, inpixel_t*, int);
+typedef void (*drawskycol_t)(int, int, int);
 typedef void (*drawspan_t)(int, int, int, int, fixed_t, fixed_t, fixed_t, fixed_t, inpixel_t*, int);
 
 extern drawcol_t drawcol;
@@ -279,7 +280,7 @@ extern drawcol_t drawcollow;
 extern drawspan_t drawspan;
 
 #ifdef MDSKY
-extern drawcol_t drawskycol;
+extern drawskycol_t drawskycol;
 #endif
 
 #define FUZZTABLE		64

--- a/r_main.c
+++ b/r_main.c
@@ -24,7 +24,7 @@ drawcol_t drawcollow;
 drawspan_t drawspan;
 
 #ifdef MDSKY
-drawcol_t drawskycol;
+drawskycol_t drawskycol;
 #endif
 
 short fuzzoffset[FUZZTABLE] =

--- a/r_phase6.c
+++ b/r_phase6.c
@@ -150,7 +150,7 @@ static void R_DrawSeg(seglocal_t* lseg, unsigned short *clipbounds)
     viswall_t* segl = lseg->segl;
 
     #ifdef MDSKY
-    drawcol_t drawsky = (segl->actionbits & AC_ADDSKY) != 0 ? drawskycol : NULL;
+    drawskycol_t drawsky = (segl->actionbits & AC_ADDSKY) != 0 ? drawskycol : NULL;
     #else
     drawcol_t drawsky = (segl->actionbits & AC_ADDSKY) != 0 ? drawcol : NULL;
     #endif
@@ -225,7 +225,7 @@ static void R_DrawSeg(seglocal_t* lseg, unsigned short *clipbounds)
             if (top < bottom)
             {
 #ifdef MDSKY
-                drawsky(x, top, --bottom, 0, 0, 0, NULL, 128);
+                drawsky(x, top, --bottom);
 #else
                 // CALICO: draw sky column
                 int colnum = ((vd.viewangle + (xtoviewangle[x]<<FRACBITS)) >> ANGLETOSKYSHIFT) & 0xff;

--- a/sh2_draw.s
+++ b/sh2_draw.s
@@ -5,6 +5,20 @@
 .equ DOOMTLS_COLORMAP, 16
 .equ DOOMTLS_FUZZPOS,  20
 
+!=======================================================================
+!Standard column draw functions use the following data sources:
+!
+! r4 = dc_x
+! r5 = dc_yl
+! r6 = dc_yh
+! r7 = light
+! @(0,r15) = frac
+! @(4,r15) = fracstep
+! @(8,r15) = dc_source
+! @(12,r15) = dc_texheight
+!=======================================================================
+
+
 ! Draw a vertical column of pixels from a projected wall texture.
 ! Source is the top of the column to scale.
 ! Low detail (doubl-wide pixels) mode.
@@ -662,8 +676,7 @@ draw_fuzzoffset:
 
 ! Clear a vertical column of pixels for the MD sky to show through.
 !
-!void I_DrawSkyColumn(int dc_x, int dc_yl, int dc_yh, int light, fixed_t frac,
-!                  fixed_t fracstep, inpixel_t *dc_source, int dc_texheight)
+!void I_DrawSkyColumn(int dc_x, int dc_yl, int dc_yh)
 
         .align  4
         .global _I_DrawSkyColumnA
@@ -688,11 +701,8 @@ _I_DrawSkyColumnA:
         add     r5,r8
         shlr2   r5
         add     r5,r8           /* fb += (dc_yl*256 + dc_yl*64) */
-        mov.l   @(8,r15),r2     /* frac */
-        mov.l   @(12,r15),r3    /* fracstep */
-        mov.l   @(16,r15),r5    /* dc_source */
-        mov.l   @(20,r15),r4
         mov.l   draw_width2,r1
+        mov.w   thru_pal_index_double,r7     /* dpix = dc_colormap[pix] */
 
         /* test if count & 1 */
         shlr    r6
@@ -702,13 +712,11 @@ _I_DrawSkyColumnA:
 
         .p2alignw 2, 0x0009
 do_sky_col_loop:
-        mov.w   thru_pal_index_double,r9     /* dpix = dc_colormap[pix] */
-        mov.w   r9,@r8          /* *fb = dpix */ /* TODO: DLG: This will fail on real hardware at odd addresses. */
+        mov.w   r7,@r8          /* *fb = dpix */ /* TODO: DLG: This will fail on real hardware at odd addresses. */
         add     r1,r8           /* fb += SCREENWIDTH */
 do_sky_col_loop_1px:
         dt      r6              /* count-- */
-        mov.w   thru_pal_index_double,r9     /* dpix = dc_colormap[pix] */
-        mov.w   r9,@r8          /* *fb = dpix */ /* TODO: DLG: This will fail on real hardware at odd addresses. */
+        mov.w   r7,@r8          /* *fb = dpix */ /* TODO: DLG: This will fail on real hardware at odd addresses. */
         bf/s    do_sky_col_loop
         add     r1,r8           /* fb += SCREENWIDTH */
 
@@ -718,10 +726,9 @@ do_sky_col_loop_1px:
 
 
 ! Clear a vertical column of pixels for the MD sky to show through.
-! Low detail (doubl-wide pixels) mode.
+! Low detail (double-wide pixels) mode.
 !
-!void I_DrawSkyColumnLow(int dc_x, int dc_yl, int dc_yh, int light, fixed_t frac,
-!                  fixed_t fracstep, inpixel_t *dc_source, int dc_texheight)
+!void I_DrawSkyColumnLow(int dc_x, int dc_yl, int dc_yh)
 
         .align  4
         .global _I_DrawSkyColumnLowA
@@ -747,11 +754,8 @@ _I_DrawSkyColumnLowA:
         add     r5,r8
         shlr2   r5
         add     r5,r8           /* fb += (dc_yl*256 + dc_yl*64) */
-        mov.l   @(8,r15),r2     /* frac */
-        mov.l   @(12,r15),r3    /* fracstep */
-        mov.l   @(16,r15),r5    /* dc_source */
-        mov.l   @(20,r15),r4
         mov.l   draw_width2,r1
+        mov.w   thru_pal_index_double,r7     /* dpix = dc_colormap[pix] */
 
         /* test if count & 1 */
         shlr    r6
@@ -761,13 +765,11 @@ _I_DrawSkyColumnLowA:
 
         .p2alignw 2, 0x0009
 do_sky_col_loop_low:
-        mov.w   thru_pal_index_double,r9     /* dpix = dc_colormap[pix] */
-        mov.w   r9,@r8          /* *fb = dpix */
+        mov.w   r7,@r8          /* *fb = dpix */
         add     r1,r8           /* fb += SCREENWIDTH */
 do_sky_col_loop_low_1px:
-        mov.w   thru_pal_index_double,r9     /* dpix = dc_colormap[pix] */
         dt      r6              /* count-- */
-        mov.w   r9,@r8          /* *fb = dpix */
+        mov.w   r7,@r8          /* *fb = dpix */
         bf/s    do_sky_col_loop_low
         add     r1,r8           /* fb += SCREENWIDTH */
 


### PR DESCRIPTION
The MD sky is a tad bit faster now (additional 7 frames shaved off of the total time in the latest demo run).

Also changed the way the ROM tries to locate the WAD file by having it do a search at 1KB intervals from 0x30000 to 0x80000. That will save us from having to update wadbase.s every time it gets moved around! Will still need to keep an eye on the ROM size defined in the header.