### PR TITLE
Frameskip using the cycle timer

### DIFF
--- a/d_main.c
+++ b/d_main.c
@@ -671,6 +671,12 @@ int MiniLoop ( void (*start)(void),  void (*stop)(void)
 
 	last_frt_count = frt_count;
 
+	if (leveltime < TICRATE / 4) // Don't include map loading times into frameskip calculation
+	{
+		accum_time = 1;
+		total_frt_count = 0;
+	}
+
 	for (int i = 0; i < accum_time; i++)
 	{
 		if (ticon & 1)

--- a/d_main.c
+++ b/d_main.c
@@ -403,260 +403,253 @@ int MiniLoop ( void (*start)(void),  void (*stop)(void)
 /* */
 /* get buttons for next tic */
 /* */
-		oldticbuttons[0] = ticbuttons[0];
-		oldticbuttons[1] = ticbuttons[1];
-		oldticrealbuttons = ticrealbuttons;
+	oldticbuttons[0] = ticbuttons[0];
+	oldticbuttons[1] = ticbuttons[1];
+	oldticrealbuttons = ticrealbuttons;
 
-			buttons = I_ReadControls();
-			buttons |= I_ReadMouse(&mx, &my);
-			if (demoplayback)
-			{
-				ticmousex[consoleplayer] = 0;
-				ticmousey[consoleplayer] = 0;
-			}
-			else
-			{
-				ticmousex[consoleplayer] = mx;
-				ticmousey[consoleplayer] = my;
-			}
+	buttons = I_ReadControls();
+	buttons |= I_ReadMouse(&mx, &my);
+	if (demoplayback)
+	{
+		ticmousex[consoleplayer] = 0;
+		ticmousey[consoleplayer] = 0;
+	}
+	else
+	{
+		ticmousex[consoleplayer] = mx;
+		ticmousey[consoleplayer] = my;
+	}
 
-			ticbuttons[consoleplayer] = buttons;
-			ticrealbuttons = buttons;
+	ticbuttons[consoleplayer] = buttons;
+	ticrealbuttons = buttons;
 
-			if (demoplayback)
-			{
+	if (demoplayback)
+	{
 #ifndef MARS
-				if (buttons & (BT_ATTACK|BT_SPEED|BT_USE) )
-				{
-					exit = ga_exitdemo;
-					break;
-				}
-#endif
-
-				#ifdef PLAY_POS_DEMO
-				if (demo_p == demobuffer + 0xA) {
-					// This is the first frame, so grab the initial values.
-					prev_rec_values[0] = players[0].mo->x;
-					prev_rec_values[1] = players[0].mo->y;
-					prev_rec_values[2] = players[0].mo->z;
-					prev_rec_values[3] = players[0].mo->angle >> ANGLETOFINESHIFT;
-
-					demo_p += 16;
-				}
-				else {
-					// Beyond the first frame, we update only the values that
-					// have changed.
-					unsigned char key = *demo_p++;
-
-					int rec_value;
-					unsigned char *prev_rec_values_bytes;
-
-					for (int i=0; i < 4; i++) {
-						// Check to see which values have changed and save them
-						// in 'prev_rec_values' so the next frame's comparisons
-						// can be done against the current frame.
-						prev_rec_values_bytes = &prev_rec_values[i];
-						rec_value = 0;
-
-						switch (key&3) {
-							case 3: // Long -- update the value as recorded (i.e. no delta).
-								rec_value = *demo_p++;
-								rec_value <<= 8;
-								rec_value |= *demo_p++;
-								rec_value <<= 8;
-								rec_value |= *demo_p++;
-								rec_value <<= 8;
-								rec_value |= *demo_p++;
-								prev_rec_values[i] = rec_value;
-								break;
-
-							case 2: // Short -- add the difference to the current value.
-								rec_value = *demo_p++;
-								rec_value <<= 8;
-								rec_value |= *demo_p++;
-								prev_rec_values[i] += (signed short)rec_value;
-								break;
-
-							case 1: // Byte -- add the difference to the current value.
-								rec_value = *demo_p++;
-								prev_rec_values[i] += (signed char)rec_value;
-						}
-
-						// Advance the key so the next two bits can be read to
-						// check for updates.
-						key >>= 2;
-					}
-
-					// Update the player variables with the newly updated
-					// frame values.
-					players[0].mo->x = prev_rec_values[0];
-					players[0].mo->y = prev_rec_values[1];
-					players[0].mo->z = prev_rec_values[2];
-					players[0].mo->angle = prev_rec_values[3] << ANGLETOFINESHIFT;
-				}
-				#endif
-
-				#ifndef PLAY_POS_DEMO
-				if (gamemapinfo.mapNumber == TITLE_MAP_NUMBER) {
-					// Rotate on the title screen.
-					ticbuttons[consoleplayer] = buttons = 0;
-					players[0].mo->angle += TITLE_ANGLE_INC;
-				}
-				else {
-					// This is for reading conventional input-based demos.
-					ticbuttons[consoleplayer] = buttons = *((long *)demobuffer);
-					demobuffer += 4;
-				}
-				#endif
-			}
-
-			if (splitscreen && !demoplayback)
-				ticbuttons[consoleplayer ^ 1] = I_ReadControls2();
-			else if (netgame)	/* may also change vblsinframe */
-				ticbuttons[consoleplayer ^ 1]
-					= NetToLocal(I_NetTransfer(LocalToNet(ticbuttons[consoleplayer])));
-
-		#ifdef PLAY_POS_DEMO
-		if (demoplayback) {
-			players[0].mo->momx = 0;
-			players[0].mo->momy = 0;
-			players[0].mo->momz = 0;
-		}
-		#endif
-
-		gamevbls += vblsinframe;
-
-		if (demorecording) {
-			#ifdef REC_POS_DEMO
-			if (((short *)demobuffer)[3] == -1) {
-				// This is the first frame, so record the initial values in full.
-				prev_rec_values[0] = players[0].mo->x;
-				prev_rec_values[1] = players[0].mo->y;
-				prev_rec_values[2] = players[0].mo->z;
-				prev_rec_values[3] = players[0].mo->angle >> ANGLETOFINESHIFT;
-
-				char *values_p = prev_rec_values;
-				for (int i=0; i < 4; i++) {
-					*demo_p++ = *values_p++;
-					*demo_p++ = *values_p++;
-					*demo_p++ = *values_p++;
-					*demo_p++ = *values_p++;
-				}
-
-				((short *)demobuffer)[2] += 16; // 16 bytes written.
-			}
-			else {
-				// Beyond the first frame, we record only the values that
-				// have changed.
-				unsigned char frame_bytes = 1; // At least one byte will be written.
-
-				// Calculate the difference between values in the current
-				// frame and previous frame.
-				fixed_t delta[4];
-				delta[0] = players[0].mo->x - prev_rec_values[0];
-				delta[1] = players[0].mo->y - prev_rec_values[1];
-				delta[2] = players[0].mo->z - prev_rec_values[2];
-				delta[3] = (players[0].mo->angle >> ANGLETOFINESHIFT) - prev_rec_values[3];
-
-				// Save the current frame's values in 'prev_rec_values' so
-				// the next frame's comparisons can be done against the
-				// current frame.
-				prev_rec_values[0] = players[0].mo->x;
-				prev_rec_values[1] = players[0].mo->y;
-				prev_rec_values[2] = players[0].mo->z;
-				prev_rec_values[3] = players[0].mo->angle >> ANGLETOFINESHIFT;
-
-				unsigned char key = 0;
-
-				// Record the values that have changed and the minimum number
-				// of bytes needed to represent the deltas.
-				for (int i=0; i < 4; i++) {
-					key >>= 2;
-
-					fixed_t d = delta[i];
-					if (d != 0) {
-						if (d <= 0x7F && d >= -0x80) {
-							key |= 0x40; // Byte
-							frame_bytes++;
-						}
-						else if (d <= 0x7FFF && d >= -0x8000) {
-							key |= 0x80; // Short
-							frame_bytes += 2;
-						}
-						else {
-							key |= 0xC0; // Long
-							frame_bytes += 4;
-						}
-					}
-				}
-
-				unsigned char *delta_bytes;
-				unsigned char *prev_rec_values_bytes;
-
-				*demo_p++ = key;
-
-				// Based on the sizes put into the key, we record either the
-				// deltas (in the case of char and short) or the full value.
-				// Values with no difference will not be recorded.
-				for (int i=0; i < 4; i++) {
-					delta_bytes = &delta[i];
-					prev_rec_values_bytes = &prev_rec_values[i];
-					switch (key & 3) {
-						case 3: // Long
-							*demo_p++ = *prev_rec_values_bytes++;
-							*demo_p++ = *prev_rec_values_bytes++;
-							*demo_p++ = *prev_rec_values_bytes++;
-							*demo_p++ = *prev_rec_values_bytes++;
-							break;
-
-						case 2: // Short
-							*demo_p++ = delta_bytes[2];
-							// fall-thru
-
-						case 1: // Byte
-							*demo_p++ = delta_bytes[3];
-					}
-
-					// Advance the key so the next two bits can be read to
-					// check for updated values.
-					key >>= 2;
-				}
-
-				((short *)demobuffer)[2] += frame_bytes;	// Increase data length.
-			}
-
-			((short *)demobuffer)[3] += 1;	// Increase frame count.
-			#endif
-
-			#ifdef REC_INPUT_DEMO
-			*((long *)demo_p) = buttons;
-			demo_p += 4;
-			#endif
-		}
-		
-		if ((demorecording || demoplayback) && (buttons & BT_PAUSE) )
-			exit = ga_completed;
-
-		if (gameaction == ga_warped || gameaction == ga_startnew)
+		if (buttons & (BT_ATTACK|BT_SPEED|BT_USE) )
 		{
-			exit = gameaction;	/* hack for NeXT level reloading and net error */
+			exit = ga_exitdemo;
 			break;
 		}
+#endif
 
-		if (!firstdraw)
-		{
-			if (update)
-				update();
+		#ifdef PLAY_POS_DEMO
+		if (demo_p == demobuffer + 0xA) {
+			// This is the first frame, so grab the initial values.
+			prev_rec_values[0] = players[0].mo->x;
+			prev_rec_values[1] = players[0].mo->y;
+			prev_rec_values[2] = players[0].mo->z;
+			prev_rec_values[3] = players[0].mo->angle >> ANGLETOFINESHIFT;
+
+			demo_p += 16;
 		}
-		firstdraw = false;
+		else {
+			// Beyond the first frame, we update only the values that
+			// have changed.
+			unsigned char key = *demo_p++;
 
-		S_PreUpdateSounds();
-		
-		int frt_count = I_GetFRTCounter();
+			int rec_value;
+			unsigned char *prev_rec_values_bytes;
 
-	if (last_frt_count == 0) {
-		last_frt_count = frt_count;
+			for (int i=0; i < 4; i++) {
+				// Check to see which values have changed and save them
+				// in 'prev_rec_values' so the next frame's comparisons
+				// can be done against the current frame.
+				prev_rec_values_bytes = &prev_rec_values[i];
+				rec_value = 0;
+
+				switch (key&3) {
+					case 3: // Long -- update the value as recorded (i.e. no delta).
+						rec_value = *demo_p++;
+						rec_value <<= 8;
+						rec_value |= *demo_p++;
+						rec_value <<= 8;
+						rec_value |= *demo_p++;
+						rec_value <<= 8;
+						rec_value |= *demo_p++;
+						prev_rec_values[i] = rec_value;
+						break;
+
+					case 2: // Short -- add the difference to the current value.
+						rec_value = *demo_p++;
+						rec_value <<= 8;
+						rec_value |= *demo_p++;
+						prev_rec_values[i] += (signed short)rec_value;
+						break;
+
+					case 1: // Byte -- add the difference to the current value.
+						rec_value = *demo_p++;
+						prev_rec_values[i] += (signed char)rec_value;
+				}
+
+				// Advance the key so the next two bits can be read to
+				// check for updates.
+				key >>= 2;
+			}
+
+			// Update the player variables with the newly updated
+			// frame values.
+			players[0].mo->x = prev_rec_values[0];
+			players[0].mo->y = prev_rec_values[1];
+			players[0].mo->z = prev_rec_values[2];
+			players[0].mo->angle = prev_rec_values[3] << ANGLETOFINESHIFT;
+		}
+#endif
+
+#ifndef PLAY_POS_DEMO
+		if (gamemapinfo.mapNumber == TITLE_MAP_NUMBER) {
+			// Rotate on the title screen.
+			ticbuttons[consoleplayer] = buttons = 0;
+			players[0].mo->angle += TITLE_ANGLE_INC;
+		}
+		else {
+			// This is for reading conventional input-based demos.
+			ticbuttons[consoleplayer] = buttons = *((long *)demobuffer);
+			demobuffer += 4;
+		}
+		#endif
 	}
+
+	#ifdef PLAY_POS_DEMO
+	if (demoplayback) {
+		players[0].mo->momx = 0;
+		players[0].mo->momy = 0;
+		players[0].mo->momz = 0;
+	}
+	#endif
+
+	gamevbls += vblsinframe;
+
+	if (demorecording) {
+		#ifdef REC_POS_DEMO
+		if (((short *)demobuffer)[3] == -1) {
+			// This is the first frame, so record the initial values in full.
+			prev_rec_values[0] = players[0].mo->x;
+			prev_rec_values[1] = players[0].mo->y;
+			prev_rec_values[2] = players[0].mo->z;
+			prev_rec_values[3] = players[0].mo->angle >> ANGLETOFINESHIFT;
+
+			char *values_p = prev_rec_values;
+			for (int i=0; i < 4; i++) {
+				*demo_p++ = *values_p++;
+				*demo_p++ = *values_p++;
+				*demo_p++ = *values_p++;
+				*demo_p++ = *values_p++;
+			}
+
+			((short *)demobuffer)[2] += 16; // 16 bytes written.
+		}
+		else {
+			// Beyond the first frame, we record only the values that
+			// have changed.
+			unsigned char frame_bytes = 1; // At least one byte will be written.
+
+			// Calculate the difference between values in the current
+			// frame and previous frame.
+			fixed_t delta[4];
+			delta[0] = players[0].mo->x - prev_rec_values[0];
+			delta[1] = players[0].mo->y - prev_rec_values[1];
+			delta[2] = players[0].mo->z - prev_rec_values[2];
+			delta[3] = (players[0].mo->angle >> ANGLETOFINESHIFT) - prev_rec_values[3];
+
+			// Save the current frame's values in 'prev_rec_values' so
+			// the next frame's comparisons can be done against the
+			// current frame.
+			prev_rec_values[0] = players[0].mo->x;
+			prev_rec_values[1] = players[0].mo->y;
+			prev_rec_values[2] = players[0].mo->z;
+			prev_rec_values[3] = players[0].mo->angle >> ANGLETOFINESHIFT;
+
+			unsigned char key = 0;
+
+			// Record the values that have changed and the minimum number
+			// of bytes needed to represent the deltas.
+			for (int i=0; i < 4; i++) {
+				key >>= 2;
+
+				fixed_t d = delta[i];
+				if (d != 0) {
+					if (d <= 0x7F && d >= -0x80) {
+						key |= 0x40; // Byte
+						frame_bytes++;
+					}
+					else if (d <= 0x7FFF && d >= -0x8000) {
+						key |= 0x80; // Short
+						frame_bytes += 2;
+					}
+					else {
+						key |= 0xC0; // Long
+						frame_bytes += 4;
+					}
+				}
+			}
+
+			unsigned char *delta_bytes;
+			unsigned char *prev_rec_values_bytes;
+
+			*demo_p++ = key;
+
+			// Based on the sizes put into the key, we record either the
+			// deltas (in the case of char and short) or the full value.
+			// Values with no difference will not be recorded.
+			for (int i=0; i < 4; i++) {
+				delta_bytes = &delta[i];
+				prev_rec_values_bytes = &prev_rec_values[i];
+				switch (key & 3) {
+					case 3: // Long
+						*demo_p++ = *prev_rec_values_bytes++;
+						*demo_p++ = *prev_rec_values_bytes++;
+						*demo_p++ = *prev_rec_values_bytes++;
+						*demo_p++ = *prev_rec_values_bytes++;
+						break;
+
+					case 2: // Short
+						*demo_p++ = delta_bytes[2];
+						// fall-thru
+
+					case 1: // Byte
+						*demo_p++ = delta_bytes[3];
+				}
+
+				// Advance the key so the next two bits can be read to
+				// check for updated values.
+				key >>= 2;
+			}
+
+			((short *)demobuffer)[2] += frame_bytes;	// Increase data length.
+		}
+
+		((short *)demobuffer)[3] += 1;	// Increase frame count.
+#endif
+
+#ifdef REC_INPUT_DEMO
+		*((long *)demo_p) = buttons;
+		demo_p += 4;
+#endif
+	}
+		
+	if ((demorecording || demoplayback) && (buttons & BT_PAUSE) )
+		exit = ga_completed;
+
+	if (gameaction == ga_warped || gameaction == ga_startnew)
+	{
+		exit = gameaction;	/* hack for NeXT level reloading and net error */
+		break;
+	}
+
+	if (!firstdraw)
+	{
+		if (update)
+			update();
+	}
+	firstdraw = false;
+
+	S_PreUpdateSounds();
+		
+	int frt_count = I_GetFRTCounter();
+
+	if (last_frt_count == 0)
+		last_frt_count = frt_count;
 
 	int accum_time = 0;
 	// Frame skipping based on FRT count
@@ -677,8 +670,28 @@ int MiniLoop ( void (*start)(void),  void (*stop)(void)
 		total_frt_count = 0;
 	}
 
+	int tempticbuttons[2];
+	int tempticmousex[2];
+	int tempticmousey[2];
+	int tempticrealbuttons = ticrealbuttons;
+	tempticbuttons[0] = ticbuttons[0];
+	tempticbuttons[1] = ticbuttons[1];
 	for (int i = 0; i < accum_time; i++)
 	{
+		ticbuttons[0] = tempticbuttons[0];
+		ticbuttons[1] = tempticbuttons[1];
+		ticmousex[0] = tempticmousex[0];
+		ticmousex[1] = tempticmousex[1];
+		ticmousey[0] = tempticmousey[0];
+		ticmousey[1] = tempticmousey[1];
+		ticrealbuttons = tempticrealbuttons;
+
+		if (splitscreen && !demoplayback)
+			ticbuttons[consoleplayer ^ 1] = I_ReadControls2();
+		else if (netgame)	/* may also change vblsinframe */
+			ticbuttons[consoleplayer ^ 1]
+				= NetToLocal(I_NetTransfer(LocalToNet(ticbuttons[consoleplayer])));
+
 		if (ticon & 1)
 			gametic++;
 			

--- a/doomdef.h
+++ b/doomdef.h
@@ -1133,8 +1133,6 @@ extern	int		maxlevel;			/* highest level selectable in menu (1-25) */
 extern	int		gamevbls;			/* may not really be vbls in multiplayer */
 extern	int		vblsinframe;			/* range from 4 to 8 */
 
-extern  int     frames_to_skip;
-
 #define MAX_FRAME_SKIP		3
 
 #define MINTICSPERFRAME		1


### PR DESCRIPTION
Do frameskip with millisecond-level accuracy. Could potentially eliminate the milliseconds here and get down to the cycle count level.