### PR TITLE
Boom water (rendering only)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ CCFLAGS += -D__32X__ -DMARS
 #CCFLAGS += -DMDSKY
 #CCFLAGS += -DREC_POS_DEMO
 #CCFLAGS += -DPLAY_POS_DEMO
-#CCFLAGS += -DHIGH_DETAIL_SPRITES
+CCFLAGS += -DHIGH_DETAIL_SPRITES
 LDFLAGS = -T mars-ssf.ld -Wl,-Map=output.map -nostdlib -Wl,--gc-sections --specs=nosys.specs
 ASFLAGS = --big
 

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ CCFLAGS += -D__32X__ -DMARS
 #CCFLAGS += -DMDSKY
 #CCFLAGS += -DREC_POS_DEMO
 #CCFLAGS += -DPLAY_POS_DEMO
-CCFLAGS += -DHIGH_DETAIL_SPRITES
+#CCFLAGS += -DHIGH_DETAIL_SPRITES
 LDFLAGS = -T mars-ssf.ld -Wl,-Map=output.map -nostdlib -Wl,--gc-sections --specs=nosys.specs
 ASFLAGS = --big
 

--- a/p_camera.c
+++ b/p_camera.c
@@ -172,6 +172,7 @@ static boolean P_CameraTryMove2(ptrymove_t *tm, boolean checkposonly)
    tmthing->ceilingz = mw.tmceilingz;
    tmthing->x = mw.tmx;
    tmthing->y = mw.tmy;
+   tmthing->subsector = mw.newsubsec;
 
    return true;
 }
@@ -324,6 +325,7 @@ camwrapup:
 		thiscam->momx = mo.momx;
 		thiscam->momy = mo.momy;
 		thiscam->momz = mo.momz;
+      thiscam->subsector = mo.subsector;
    }
 
 	// P_CameraZMovement()

--- a/p_setup.c
+++ b/p_setup.c
@@ -207,6 +207,10 @@ void P_LoadSectors (int lump)
 		ss->special = special;
 
 		ss->tag = LITTLESHORT(ms->tag);
+		ss->heightsec = -1; // sector used to get floor and ceiling height
+		ss->floorlightsec = -1;   // sector used to get floor lighting
+		// killough 4/11/98 sector used to get ceiling lighting:
+		ss->ceilinglightsec = -1;
 	}
 }
 

--- a/p_spec.c
+++ b/p_spec.c
@@ -954,9 +954,9 @@ void P_SpawnSpecials (void)
 			EV_DoFloor(&lines[i], floorContinuous);
 			break;
 		case 242: // Boom water
-			sector_t *sec = &sectors[sides[*lines[i].sidenum].sector];
+			VINT sec = sides[*lines[i].sidenum].sector;
 			for (int s = -1; (s = P_FindSectorFromLineTag(lines+i,s)) >= 0;)
-			sectors[s].heightsec = sec;
+				sectors[s].heightsec = sec;
 			break;
 		}
 	}

--- a/p_spec.c
+++ b/p_spec.c
@@ -953,6 +953,11 @@ void P_SpawnSpecials (void)
 		case 60: // Moving platform
 			EV_DoFloor(&lines[i], floorContinuous);
 			break;
+		case 242: // Boom water
+			sector_t *sec = &sectors[sides[*lines[i].sidenum].sector];
+			for (int s = -1; (s = P_FindSectorFromLineTag(lines+i,s)) >= 0;)
+			sectors[s].heightsec = sec;
+			break;
 		}
 	}
 done_speciallist:

--- a/r_local.h
+++ b/r_local.h
@@ -274,7 +274,7 @@ void	R_SetDrawMode(void);
 void	R_SetupLevel(void);
 void	R_SetupTextureCaches(void);
 // killough 4/13/98: fake floors/ceilings for deep water / fake ceilings:
-sector_t *R_FakeFlat(sector_t *, sector_t *, uint8_t *, uint8_t *, boolean);
+sector_t *R_FakeFlat(sector_t *, sector_t *, boolean);
 
 typedef void (*drawcol_t)(int, int, int, int, fixed_t, fixed_t, inpixel_t*, int);
 typedef void (*drawskycol_t)(int, int, int);
@@ -545,7 +545,8 @@ typedef struct vissprite_s
 	VINT 		patchnum;
 	VINT		colormap;		/* < 0 = shadow draw */
 	short		gx,gy;	/* global coordinates */
-	void 		*colormaps;
+	VINT        heightsec;
+//	void 		*colormaps;
 #ifndef MARS
 	pixel_t		*pixels;		/* data patch header references */
 #endif

--- a/r_local.h
+++ b/r_local.h
@@ -73,6 +73,11 @@ typedef	struct
 	VINT		linecount;
 
 	VINT		tag;
+	// killough 3/7/98: support flat heights drawn at another sector's heights
+  	VINT        heightsec;    // other sector, or -1 if no other sector
+
+	// killough 4/11/98: support for lightlevels coming from another sector
+	VINT floorlightsec, ceilinglightsec;
 
 	VINT		blockbox[4];		/* mapblock bounding box for height changes */
 
@@ -268,6 +273,8 @@ int		R_DefaultViewportSize(void); // returns the viewport id for fullscreen, low
 void	R_SetDrawMode(void);
 void	R_SetupLevel(void);
 void	R_SetupTextureCaches(void);
+// killough 4/13/98: fake floors/ceilings for deep water / fake ceilings:
+sector_t *R_FakeFlat(sector_t *, sector_t *, uint8_t *, uint8_t *, boolean);
 
 typedef void (*drawcol_t)(int, int, int, int, fixed_t, fixed_t, inpixel_t*, int);
 typedef void (*drawskycol_t)(int, int, int);
@@ -590,6 +597,7 @@ __attribute__((aligned(16)))
 {
 	fixed_t		viewx, viewy, viewz;
 	angle_t		viewangle;
+	subsector_t *viewsubsector;
 	fixed_t		viewcos, viewsin;
 	player_t	*viewplayer;
 	VINT		lightlevel;

--- a/r_local.h
+++ b/r_local.h
@@ -546,6 +546,7 @@ typedef struct vissprite_s
 	VINT		colormap;		/* < 0 = shadow draw */
 	short		gx,gy;	/* global coordinates */
 	VINT        heightsec;
+	VINT		patchheight;
 //	void 		*colormaps;
 #ifndef MARS
 	pixel_t		*pixels;		/* data patch header references */

--- a/r_main.c
+++ b/r_main.c
@@ -530,6 +530,7 @@ static void R_Setup (int displayplayer, visplane_t *visplanes_,
 		vd.viewangle = thiscam->angle;
 		vd.lightlevel = thiscam->subsector->sector->lightlevel;
 		aimingangle = thiscam->aiming;
+		vd.viewsubsector = thiscam->subsector;
 	}
 	else
 	{
@@ -538,6 +539,7 @@ static void R_Setup (int displayplayer, visplane_t *visplanes_,
 		vd.viewz = player->viewz;
 		vd.viewangle = player->mo->angle;
 		vd.lightlevel = player->mo->subsector->sector->lightlevel;
+		vd.viewsubsector = player->mo->subsector;
 	}
 
 	vd.viewplayer = player;
@@ -843,6 +845,42 @@ visplane_t* R_FindPlane(fixed_t height,
 	check->flatandlight = flatandlight;
 	check->minx = start;
 	check->maxx = stop;
+
+	R_MarkOpenPlane(check);
+
+	check->next = tail;
+	vd.visplanes_hash[hash] = check;
+
+	return check;
+}
+
+visplane_t* R_FindPlane2(fixed_t height, 
+	int flatandlight)
+{
+	visplane_t *check, *tail, *next;
+	int hash = R_PlaneHash(height, flatandlight);
+
+	tail = vd.visplanes_hash[hash];
+	for (check = tail; check; check = next)
+	{
+		next = check->next;
+
+		if (height == check->height && // same plane as before?
+			flatandlight == check->flatandlight)
+			return check; // use the same one as before
+	}
+
+	if (vd.lastvisplane == vd.visplanes + MAXVISPLANES)
+		return vd.visplanes;
+
+	// make a new plane
+	check = vd.lastvisplane;
+	++vd.lastvisplane;
+
+	check->height = height;
+	check->flatandlight = flatandlight;
+	check->minx = 320;
+	check->maxx = -1;
 
 	R_MarkOpenPlane(check);
 

--- a/r_phase1.c
+++ b/r_phase1.c
@@ -66,7 +66,7 @@ static VINT checkcoord[12][4] =
    { 0, 0, 0, 0 }
 };
 
-static sector_t emptysector = { 0, 0, -2, -2, -2 };
+static sector_t emptysector = { 0, 0, -2, -2, -2, 0, 0, 0, 0, -1 };
 
 static int R_ClipToViewEdges(angle_t angle1, angle_t angle2)
 {
@@ -199,7 +199,7 @@ static void R_WallEarlyPrep(rbspWork_t *rbsp, viswall_t* segl,
    static sector_t ftempsec;
    static sector_t btempsec;
 
-//   front_sector = R_FakeFlat(front_sector, &ftempsec, false);
+   front_sector = R_FakeFlat(front_sector, &ftempsec, false);
 
    {
       li->flags |= ML_MAPPED; // mark as seen
@@ -228,8 +228,8 @@ static void R_WallEarlyPrep(rbspWork_t *rbsp, viswall_t* segl,
 
       if (!back_sector)
          back_sector = &emptysector;
-//      else
-//         back_sector = R_FakeFlat(back_sector, &btempsec, true);
+      else
+         back_sector = R_FakeFlat(back_sector, &btempsec, true);
 
       b_ceilingpic    = back_sector->ceilingpic;
       b_lightlevel    = back_sector->lightlevel;
@@ -568,8 +568,8 @@ crunch:
 sector_t *R_FakeFlat(sector_t *sec, sector_t *tempsec,
                      boolean back)
 {
-  if (sec->heightsec != -1)
-    {
+   if (sec->heightsec != -1)
+   {
       const sector_t *s = &sectors[sec->heightsec];
       int heightsec = vd.viewsubsector->sector->heightsec;
       int underwater = heightsec!=-1 && vd.viewz<=sectors[heightsec].floorheight;
@@ -581,57 +581,58 @@ sector_t *R_FakeFlat(sector_t *sec, sector_t *tempsec,
       tempsec->floorheight   = s->floorheight;
       tempsec->ceilingheight = s->ceilingheight;
 
-      if ((underwater && (tempsec->  floorheight = sec->floorheight,
+      if ((underwater && (tempsec-> floorheight = sec->floorheight,
                           tempsec->ceilingheight = s->floorheight-1,
                           !back)) || vd.viewz <= s->floorheight)
-        {                   // head-below-floor hack
-          tempsec->floorpic    = s->floorpic;
-//          tempsec->floor_xoffs = s->floor_xoffs;
-//          tempsec->floor_yoffs = s->floor_yoffs;
+      { // head-below-floor hack
+         tempsec->floorpic    = s->floorpic;
+//       tempsec->floor_xoffs = s->floor_xoffs;
+//       tempsec->floor_yoffs = s->floor_yoffs;
 
-          if (underwater)
-          {
+         if (underwater)
+         {
             if (s->ceilingpic == -1)
-              {
-                tempsec->floorheight   = tempsec->ceilingheight+1;
-                tempsec->ceilingpic    = tempsec->floorpic;
-//                tempsec->ceiling_xoffs = tempsec->floor_xoffs;
-//                tempsec->ceiling_yoffs = tempsec->floor_yoffs;
-              }
+            {
+               tempsec->floorheight   = tempsec->ceilingheight+1;
+               tempsec->ceilingpic    = tempsec->floorpic;
+//             tempsec->ceiling_xoffs = tempsec->floor_xoffs;
+//             tempsec->ceiling_yoffs = tempsec->floor_yoffs;
+            }
             else
-              {
-                tempsec->ceilingpic    = s->ceilingpic;
-//                tempsec->ceiling_xoffs = s->ceiling_xoffs;
-//                tempsec->ceiling_yoffs = s->ceiling_yoffs;
-              }
-          }
+            {
+               tempsec->ceilingpic    = s->ceilingpic;
+//             tempsec->ceiling_xoffs = s->ceiling_xoffs;
+//             tempsec->ceiling_yoffs = s->ceiling_yoffs;
+            }
+         }
 
-          tempsec->lightlevel  = s->lightlevel;
-        }
-      else
-        if (heightsec != -1 && vd.viewz >= sectors[heightsec].ceilingheight &&
+         tempsec->lightlevel = s->lightlevel;
+      }
+      else if (heightsec != -1 && vd.viewz >= sectors[heightsec].ceilingheight &&
             sec->ceilingheight > s->ceilingheight)
-          {   // Above-ceiling hack
-            tempsec->ceilingheight = s->ceilingheight;
-            tempsec->floorheight   = s->ceilingheight + 1;
+      {   // Above-ceiling hack
+         tempsec->ceilingheight = s->ceilingheight;
+         tempsec->floorheight   = s->ceilingheight + 1;
 
-            tempsec->floorpic    = tempsec->ceilingpic    = s->ceilingpic;
-//            tempsec->floor_xoffs = tempsec->ceiling_xoffs = s->ceiling_xoffs;
-//            tempsec->floor_yoffs = tempsec->ceiling_yoffs = s->ceiling_yoffs;
+         tempsec->floorpic    = tempsec->ceilingpic    = s->ceilingpic;
+//       tempsec->floor_xoffs = tempsec->ceiling_xoffs = s->ceiling_xoffs;
+//       tempsec->floor_yoffs = tempsec->ceiling_yoffs = s->ceiling_yoffs;
 
-            if (s->floorpic != -1)
-              {
-                tempsec->ceilingheight = sec->ceilingheight;
-                tempsec->floorpic      = s->floorpic;
-//                tempsec->floor_xoffs   = s->floor_xoffs;
-//                tempsec->floor_yoffs   = s->floor_yoffs;
-              }
+         if (s->floorpic != -1)
+         {
+            tempsec->ceilingheight = sec->ceilingheight;
+            tempsec->floorpic      = s->floorpic;
+//          tempsec->floor_xoffs   = s->floor_xoffs;
+//          tempsec->floor_yoffs   = s->floor_yoffs;
+         }
 
-            tempsec->lightlevel  = s->lightlevel;
-          }
+         tempsec->lightlevel  = s->lightlevel;
+      }
+
       sec = tempsec;               // Use other sector
-    }
-  return sec;
+   }
+
+   return sec;
 }
 
 //

--- a/r_phase1.c
+++ b/r_phase1.c
@@ -199,7 +199,7 @@ static void R_WallEarlyPrep(rbspWork_t *rbsp, viswall_t* segl,
    static sector_t ftempsec;
    static sector_t btempsec;
 
-   front_sector = R_FakeFlat(front_sector, &ftempsec, false);
+//   front_sector = R_FakeFlat(front_sector, &ftempsec, false);
 
    {
       li->flags |= ML_MAPPED; // mark as seen
@@ -228,8 +228,8 @@ static void R_WallEarlyPrep(rbspWork_t *rbsp, viswall_t* segl,
 
       if (!back_sector)
          back_sector = &emptysector;
-      else
-         back_sector = R_FakeFlat(back_sector, &btempsec, true);
+//      else
+//         back_sector = R_FakeFlat(back_sector, &btempsec, true);
 
       b_ceilingpic    = back_sector->ceilingpic;
       b_lightlevel    = back_sector->lightlevel;
@@ -674,7 +674,7 @@ static void R_AddLine(rbspWork_t *rbsp, seg_t *line)
    // decide which clip routine to use
    side = line->sideoffset & 1;
    ldef = &lines[line->linedef];
-   frontsector = R_FakeFlat(rbsp->curfsector, &ftempsec, false);
+   frontsector = rbsp->curfsector;//R_FakeFlat(rbsp->curfsector, &ftempsec, false);
    backsector = (ldef->flags & ML_TWOSIDED) ? &sectors[sides[ldef->sidenum[side^1]].sector] : 0;
    sidedef = &sides[ldef->sidenum[side]];
    solid = false;
@@ -684,7 +684,7 @@ static void R_AddLine(rbspWork_t *rbsp, seg_t *line)
       solid = true;
    else
    {
-      backsector = R_FakeFlat(backsector, &btempsec, true);
+//      backsector = R_FakeFlat(backsector, &btempsec, true);
       if (backsector->ceilingheight <= frontsector->floorheight ||
          backsector->floorheight >= frontsector->ceilingheight)
       {

--- a/r_phase1.c
+++ b/r_phase1.c
@@ -604,9 +604,8 @@ sector_t *R_FakeFlat(sector_t *sec, sector_t *tempsec,
 //             tempsec->ceiling_xoffs = s->ceiling_xoffs;
 //             tempsec->ceiling_yoffs = s->ceiling_yoffs;
             }
+            tempsec->lightlevel = s->lightlevel;
          }
-
-         tempsec->lightlevel = s->lightlevel;
       }
       else if (heightsec != -1 && vd.viewz >= sectors[heightsec].ceilingheight &&
             sec->ceilingheight > s->ceilingheight)

--- a/r_phase3.c
+++ b/r_phase3.c
@@ -116,14 +116,34 @@ static void R_PrepMobj(mobj_t *thing)
 //   if (tz > centerYFrac)
 //       return;
 
-   texmid = gzt + ((fixed_t)BIGSHORT(patch->topoffset) << FRACBITS);
 //   tz = FixedMul(texmid, xscale);
 //   if (tz < viewportHeight - centerYFrac)
 //       return;
 
+   // killough 3/27/98: exclude things totally separated
+   // from the viewer, by either water or fake ceilings
+   // killough 4/11/98: improve sprite clipping for underwater/fake ceilings
+   int heightsec = thing->subsector->sector->heightsec;
+
+   if (heightsec != -1)   // only clip things which are in special sectors
+   {
+      int phs = vd.viewsubsector->sector->heightsec;
+      if (phs != -1 && vd.viewz < sectors[phs].floorheight ?
+         thing->z >= sectors[heightsec].floorheight :
+         gzt < sectors[heightsec].floorheight)
+         return;
+      if (phs != -1 && vd.viewz > sectors[phs].ceilingheight ?
+         gzt < sectors[heightsec].ceilingheight &&
+         vd.viewz >= sectors[heightsec].ceilingheight :
+         thing->z >= sectors[heightsec].ceilingheight)
+         return;
+   }
+
    // get a new vissprite
    if(vd.vissprite_p >= vd.vissprites + MAXVISSPRITES)
       return; // too many visible sprites already, leave room for psprites
+
+   texmid = gzt + ((fixed_t)BIGSHORT(patch->topoffset) << FRACBITS);
 
    vis = (vissprite_t *)vd.vissprite_p;
    vd.vissprite_p++;
@@ -262,14 +282,34 @@ static void R_PrepRing(mobj_t *thing)
 //   if (tz > centerYFrac)
 //       return;
 
-   texmid = gzt + ((fixed_t)BIGSHORT(patch->topoffset) << FRACBITS);
 //   tz = FixedMul(texmid, xscale);
 //   if (tz < viewportHeight - centerYFrac)
 //       return;
 
+   // killough 3/27/98: exclude things totally separated
+   // from the viewer, by either water or fake ceilings
+   // killough 4/11/98: improve sprite clipping for underwater/fake ceilings
+   int heightsec = thing->subsector->sector->heightsec;
+
+   if (heightsec != -1)   // only clip things which are in special sectors
+   {
+      int phs = vd.viewsubsector->sector->heightsec;
+      if (phs != -1 && vd.viewz < sectors[phs].floorheight ?
+         thing->z >= sectors[heightsec].floorheight :
+         gzt < sectors[heightsec].floorheight)
+         return;
+      if (phs != -1 && vd.viewz > sectors[phs].ceilingheight ?
+         gzt < sectors[heightsec].ceilingheight &&
+         vd.viewz >= sectors[heightsec].ceilingheight :
+         thing->z >= sectors[heightsec].ceilingheight)
+         return;
+   }
+
    // get a new vissprite
    if(vd.vissprite_p >= vd.vissprites + MAXVISSPRITES)
       return; // too many visible sprites already, leave room for psprites
+
+   texmid = gzt + ((fixed_t)BIGSHORT(patch->topoffset) << FRACBITS);
 
    vis = (vissprite_t *)vd.vissprite_p;
    vd.vissprite_p++;
@@ -395,14 +435,34 @@ static void R_PrepScenery(scenerymobj_t *thing)
 //   if (tz > centerYFrac)
 //       return;
 
-   texmid = gzt + ((fixed_t)BIGSHORT(patch->topoffset) << FRACBITS);
 //   tz = FixedMul(texmid, xscale);
 //   if (tz < viewportHeight - centerYFrac)
 //       return;
 
+   // killough 3/27/98: exclude things totally separated
+   // from the viewer, by either water or fake ceilings
+   // killough 4/11/98: improve sprite clipping for underwater/fake ceilings
+   int heightsec = subsectors[thing->subsector].sector->heightsec;
+
+   if (heightsec != -1)   // only clip things which are in special sectors
+   {
+      int phs = vd.viewsubsector->sector->heightsec;
+      if (phs != -1 && vd.viewz < sectors[phs].floorheight ?
+         thing->z >= sectors[heightsec].floorheight :
+         gzt < sectors[heightsec].floorheight)
+         return;
+      if (phs != -1 && vd.viewz > sectors[phs].ceilingheight ?
+         gzt < sectors[heightsec].ceilingheight &&
+         vd.viewz >= sectors[heightsec].ceilingheight :
+         thing->z >= sectors[heightsec].ceilingheight)
+         return;
+   }
+
    // get a new vissprite
    if(vd.vissprite_p >= vd.vissprites + MAXVISSPRITES)
       return; // too many visible sprites already, leave room for psprites
+
+   texmid = gzt + ((fixed_t)BIGSHORT(patch->topoffset) << FRACBITS);
 
    vis = (vissprite_t *)vd.vissprite_p;
    vd.vissprite_p++;

--- a/r_phase3.c
+++ b/r_phase3.c
@@ -18,10 +18,9 @@ void R_SpritePrep(void) ATTR_DATA_CACHE_ALIGN __attribute__((noinline));
 static void R_PrepMobj(mobj_t *thing)
 {
    fixed_t tr_x, tr_y;
-   fixed_t gxt, gyt, gzt;
+   fixed_t gxt, gyt;
    fixed_t tx, tz, x1, x2;
    fixed_t xscale;
-   fixed_t texmid;
    spritedef_t   *sprdef;
    spriteframe_t *sprframe;
    VINT         *sprlump;
@@ -88,7 +87,6 @@ static void R_PrepMobj(mobj_t *thing)
 
    patch = W_POINTLUMPNUM(lump);
    xscale = FixedDiv(PROJECTION, tz);
-   gzt = thing->z - vd.viewz;
 
    // calculate edges of the shape
    if (flip)
@@ -127,23 +125,30 @@ static void R_PrepMobj(mobj_t *thing)
 
    if (heightsec != -1)   // only clip things which are in special sectors
    {
-      int phs = vd.viewsubsector->sector->heightsec;
-      if (phs != -1 && vd.viewz < sectors[phs].floorheight ?
-         thing->z >= sectors[heightsec].floorheight :
-         gzt < sectors[heightsec].floorheight)
-         return;
-      if (phs != -1 && vd.viewz > sectors[phs].ceilingheight ?
-         gzt < sectors[heightsec].ceilingheight &&
-         vd.viewz >= sectors[heightsec].ceilingheight :
-         thing->z >= sectors[heightsec].ceilingheight)
-         return;
+      const sector_t *heightsector = &sectors[heightsec];
+      const int phs = vd.viewsubsector->sector->heightsec;
+
+      if (phs != -1)
+      {
+         const fixed_t localgzt = thing->z + ((fixed_t)BIGSHORT(patch->topoffset) << FRACBITS);
+
+         if (vd.viewz < sectors[phs].floorheight ?
+            thing->z >= heightsector->floorheight :
+            localgzt < heightsector->floorheight)
+            return;
+         if (vd.viewz > sectors[phs].ceilingheight ?
+            localgzt < heightsector->ceilingheight &&
+            vd.viewz >= heightsector->ceilingheight :
+            thing->z >= heightsector->ceilingheight)
+            return;
+      }
    }
 
    // get a new vissprite
    if(vd.vissprite_p >= vd.vissprites + MAXVISSPRITES)
       return; // too many visible sprites already, leave room for psprites
 
-   texmid = gzt + ((fixed_t)BIGSHORT(patch->topoffset) << FRACBITS);
+   const fixed_t texmid = (thing->z - vd.viewz) + ((fixed_t)BIGSHORT(patch->topoffset) << FRACBITS);
 
    vis = (vissprite_t *)vd.vissprite_p;
    vd.vissprite_p++;
@@ -201,10 +206,9 @@ static void R_PrepMobj(mobj_t *thing)
 static void R_PrepRing(mobj_t *thing)
 {
    fixed_t tr_x, tr_y;
-   fixed_t gxt, gyt, gzt;
+   fixed_t gxt, gyt;
    fixed_t tx, tz, x1, x2;
    fixed_t xscale;
-   fixed_t texmid;
    spritedef_t   *sprdef;
    spriteframe_t *sprframe;
    VINT         *sprlump;
@@ -254,7 +258,6 @@ static void R_PrepRing(mobj_t *thing)
 
    patch = W_POINTLUMPNUM(lump);
    xscale = FixedDiv(PROJECTION, tz);
-   gzt = thing->z - vd.viewz;
 
    // calculate edges of the shape
    if (flip)
@@ -293,23 +296,30 @@ static void R_PrepRing(mobj_t *thing)
 
    if (heightsec != -1)   // only clip things which are in special sectors
    {
-      int phs = vd.viewsubsector->sector->heightsec;
-      if (phs != -1 && vd.viewz < sectors[phs].floorheight ?
-         thing->z >= sectors[heightsec].floorheight :
-         gzt < sectors[heightsec].floorheight)
-         return;
-      if (phs != -1 && vd.viewz > sectors[phs].ceilingheight ?
-         gzt < sectors[heightsec].ceilingheight &&
-         vd.viewz >= sectors[heightsec].ceilingheight :
-         thing->z >= sectors[heightsec].ceilingheight)
-         return;
+      const sector_t *heightsector = &sectors[heightsec];
+      const int phs = vd.viewsubsector->sector->heightsec;
+
+      if (phs != -1)
+      {
+         const fixed_t localgzt = thing->z + ((fixed_t)BIGSHORT(patch->topoffset) << FRACBITS);
+
+         if (vd.viewz < sectors[phs].floorheight ?
+            thing->z >= heightsector->floorheight :
+            localgzt < heightsector->floorheight)
+            return;
+         if (vd.viewz > sectors[phs].ceilingheight ?
+            localgzt < heightsector->ceilingheight &&
+            vd.viewz >= heightsector->ceilingheight :
+            thing->z >= heightsector->ceilingheight)
+            return;
+      }
    }
 
    // get a new vissprite
    if(vd.vissprite_p >= vd.vissprites + MAXVISSPRITES)
       return; // too many visible sprites already, leave room for psprites
 
-   texmid = gzt + ((fixed_t)BIGSHORT(patch->topoffset) << FRACBITS);
+   const fixed_t texmid = (thing->z - vd.viewz) + ((fixed_t)BIGSHORT(patch->topoffset) << FRACBITS);
 
    vis = (vissprite_t *)vd.vissprite_p;
    vd.vissprite_p++;
@@ -354,10 +364,9 @@ static void R_PrepRing(mobj_t *thing)
 static void R_PrepScenery(scenerymobj_t *thing)
 {
    fixed_t tr_x, tr_y;
-   fixed_t gxt, gyt, gzt;
+   fixed_t gxt, gyt;
    fixed_t tx, tz, x1, x2;
    fixed_t xscale;
-   fixed_t texmid;
    spritedef_t   *sprdef;
    spriteframe_t *sprframe;
    VINT         *sprlump;
@@ -407,7 +416,6 @@ static void R_PrepScenery(scenerymobj_t *thing)
 
    patch = W_POINTLUMPNUM(lump);
    xscale = FixedDiv(PROJECTION, tz);
-   gzt = (thing->z << FRACBITS) - vd.viewz;
 
    // calculate edges of the shape
    if (flip)
@@ -439,30 +447,11 @@ static void R_PrepScenery(scenerymobj_t *thing)
 //   if (tz < viewportHeight - centerYFrac)
 //       return;
 
-   // killough 3/27/98: exclude things totally separated
-   // from the viewer, by either water or fake ceilings
-   // killough 4/11/98: improve sprite clipping for underwater/fake ceilings
-   int heightsec = subsectors[thing->subsector].sector->heightsec;
-
-   if (heightsec != -1)   // only clip things which are in special sectors
-   {
-      int phs = vd.viewsubsector->sector->heightsec;
-      if (phs != -1 && vd.viewz < sectors[phs].floorheight ?
-         thing->z >= sectors[heightsec].floorheight :
-         gzt < sectors[heightsec].floorheight)
-         return;
-      if (phs != -1 && vd.viewz > sectors[phs].ceilingheight ?
-         gzt < sectors[heightsec].ceilingheight &&
-         vd.viewz >= sectors[heightsec].ceilingheight :
-         thing->z >= sectors[heightsec].ceilingheight)
-         return;
-   }
-
    // get a new vissprite
    if(vd.vissprite_p >= vd.vissprites + MAXVISSPRITES)
       return; // too many visible sprites already, leave room for psprites
 
-   texmid = gzt + ((fixed_t)BIGSHORT(patch->topoffset) << FRACBITS);
+   const fixed_t texmid = ((thing->z << FRACBITS) - vd.viewz) + ((fixed_t)BIGSHORT(patch->topoffset) << FRACBITS);
 
    vis = (vissprite_t *)vd.vissprite_p;
    vd.vissprite_p++;

--- a/r_phase3.c
+++ b/r_phase3.c
@@ -163,6 +163,7 @@ static void R_PrepMobj(mobj_t *thing)
    vis->gy       = thing->y >> FRACBITS;
    vis->xscale   = xscale;
    vis->yscale   = FixedMul(xscale, stretch);
+   vis->patchheight = BIGSHORT(patch->height);
    vis->texturemid = texmid;
    vis->startfrac = 0;
    vis->heightsec = thing->subsector->sector->heightsec;
@@ -217,7 +218,6 @@ static void R_PrepRing(mobj_t *thing)
    int          lump;
    patch_t      *patch;
    vissprite_t  *vis;
-   return;
 
    const state_t *state = &states[ringmobjstates[thing->type]];
    const VINT thingframe = state->frame;
@@ -336,6 +336,7 @@ static void R_PrepRing(mobj_t *thing)
    vis->gy       = thing->y >> FRACBITS;
    vis->xscale   = xscale;
    vis->yscale   = FixedMul(xscale, stretch);
+   vis->patchheight = BIGSHORT(patch->height);
    vis->texturemid = texmid;
    vis->startfrac = 0;
    vis->heightsec = thing->subsector->sector->heightsec;
@@ -377,7 +378,6 @@ static void R_PrepScenery(scenerymobj_t *thing)
    int          lump;
    patch_t      *patch;
    vissprite_t  *vis;
-   return;
 
    const state_t *state = &states[ringmobjstates[thing->type]];
    const VINT thingframe = state->frame;

--- a/r_phase3.c
+++ b/r_phase3.c
@@ -200,7 +200,7 @@ static void R_PrepMobj(mobj_t *thing)
        vis->colormap = HWLIGHT(vis->colormap);
    }
 
-   vis->colormaps = dc_colormaps;
+//   vis->colormaps = dc_colormaps;
 }
 
 static void R_PrepRing(mobj_t *thing)
@@ -358,7 +358,7 @@ static void R_PrepRing(mobj_t *thing)
    else
       vis->colormap = HWLIGHT(thing->subsector->sector->lightlevel);
  
-   vis->colormaps = dc_colormaps;
+//   vis->colormaps = dc_colormaps;
 }
 
 static void R_PrepScenery(scenerymobj_t *thing)
@@ -490,7 +490,7 @@ static void R_PrepScenery(scenerymobj_t *thing)
    else
       vis->colormap = HWLIGHT(subsectors[thing->subsector].sector->lightlevel);
  
-   vis->colormaps = dc_colormaps;
+//   vis->colormaps = dc_colormaps;
 }
 
 //

--- a/r_phase3.c
+++ b/r_phase3.c
@@ -165,6 +165,7 @@ static void R_PrepMobj(mobj_t *thing)
    vis->yscale   = FixedMul(xscale, stretch);
    vis->texturemid = texmid;
    vis->startfrac = 0;
+   vis->heightsec = thing->subsector->sector->heightsec;
 
    if(flip)
    {
@@ -216,6 +217,7 @@ static void R_PrepRing(mobj_t *thing)
    int          lump;
    patch_t      *patch;
    vissprite_t  *vis;
+   return;
 
    const state_t *state = &states[ringmobjstates[thing->type]];
    const VINT thingframe = state->frame;
@@ -336,6 +338,7 @@ static void R_PrepRing(mobj_t *thing)
    vis->yscale   = FixedMul(xscale, stretch);
    vis->texturemid = texmid;
    vis->startfrac = 0;
+   vis->heightsec = thing->subsector->sector->heightsec;
 
    if(flip)
    {
@@ -374,6 +377,7 @@ static void R_PrepScenery(scenerymobj_t *thing)
    int          lump;
    patch_t      *patch;
    vissprite_t  *vis;
+   return;
 
    const state_t *state = &states[ringmobjstates[thing->type]];
    const VINT thingframe = state->frame;
@@ -466,8 +470,10 @@ static void R_PrepScenery(scenerymobj_t *thing)
    vis->gy       = thing->y;
    vis->xscale   = xscale;
    vis->yscale   = FixedMul(xscale, stretch);
+   vis->patchheight = BIGSHORT(patch->height);
    vis->texturemid = texmid;
    vis->startfrac = 0;
+   vis->heightsec = -1;
 
    if(flip)
    {

--- a/r_phase8.c
+++ b/r_phase8.c
@@ -168,20 +168,20 @@ void R_DrawVisSprite(vissprite_t *vis, unsigned short *spropening, int sprscreen
 
 #ifdef HIGH_DETAIL_SPRITES
    if (lowResMode) {
-      dcol      = vis->colormap < 0 ? drawfuzzcol : drawspritecol;
+      dcol      = drawspritecol;
    }
    else {
-      dcol      = vis->colormap < 0 ? drawfuzzcol : drawcol;
+      dcol      = drawcol;
    }
 #else
-   dcol      = vis->colormap < 0 ? drawfuzzcol : drawcol;
+   dcol      = drawcol;
 #endif
 
    sprtop = FixedMul(vis->texturemid, spryscale);
    sprtop = centerYFrac - sprtop;
 
    // blitter iinc
-   light    = vis->colormap < 0 ? -vis->colormap : vis->colormap;
+   light    = vis->colormap;
    x        = vis->x1;
    stopx    = vis->x2 + 1;
    fracstep = vis->xiscale;


### PR DESCRIPTION
Adds support for TeamTNT's Boom linedef type 242 (transfer heights). Includes sprite clipping.

Possibly not a completely perfect port, will adjust as issues are encountered.