### PR TITLE
Pack viswall_t even smaller

### DIFF
--- a/p_spec.c
+++ b/p_spec.c
@@ -954,10 +954,12 @@ void P_SpawnSpecials (void)
 			EV_DoFloor(&lines[i], floorContinuous);
 			break;
 		case 242: // Boom water
+		{
 			VINT sec = sides[*lines[i].sidenum].sector;
 			for (int s = -1; (s = P_FindSectorFromLineTag(lines+i,s)) >= 0;)
 				sectors[s].heightsec = sec;
 			break;
+		}
 		}
 	}
 done_speciallist:

--- a/r_local.h
+++ b/r_local.h
@@ -541,7 +541,7 @@ typedef struct
 	fixed_t 	floorheight, floornewheight, ceilnewheight, pad;
 } viswallextra_t;
 
-#define	MAXWALLCMDS		130
+#define	MAXWALLCMDS		140
 
 /* A vissprite_t is a thing that will be drawn during a refresh */
 typedef struct vissprite_s

--- a/r_local.h
+++ b/r_local.h
@@ -497,11 +497,9 @@ typedef struct
 	int 		m_texturemid;
 
 	VINT 	m_texturenum;
-	VINT		t_texturenum;
-	VINT		b_texturenum;
+	VINT     tb_texturenum; // t_texturenum top word, b_texturenum bottom word
 
-	VINT     floorpicnum;
-	VINT     ceilingpicnum;
+	VINT     floorceilpicnum; // ceilingpicnum top word, floorpicnum bottom word (just like a ceiling and floor!)
 
 	int			scalestep;		/* polar angle to start at phase1, then scalestep after phase2 */
 	unsigned	scalefrac;
@@ -530,6 +528,17 @@ typedef struct
 
 	uint16_t 		*clipbounds;
 } viswall_t;
+
+#define UPPER8(x) (x >> 8)
+#define LOWER8(x) (x & 0xff)
+#define SETUPPER8(x, y) {\
+x &= 0x00ff; \
+x |= (y << 8); \
+}
+#define SETLOWER8(x, y) {\
+x &= 0xff00; \
+x |= (y & 0xff); \
+}
 
 typedef struct
 {

--- a/r_local.h
+++ b/r_local.h
@@ -492,11 +492,11 @@ typedef struct
 	int 		m_texturemid;
 
 	VINT 	m_texturenum;
-	VINT     tb_texturenum; // t_texturenum top word, b_texturenum bottom word
+	uint16_t     tb_texturenum; // t_texturenum top word, b_texturenum bottom word
 
-	VINT     floorceilpicnum; // ceilingpicnum top word, floorpicnum bottom word (just like a ceiling and floor!)
+	uint16_t     floorceilpicnum; // ceilingpicnum top word, floorpicnum bottom word (just like a ceiling and floor!)
 
-	VINT	newmiplevels; // 0 is lower, 1 is upper
+	uint16_t	newmiplevels; // 0 is lower, 1 is upper
 
 	int			scalestep;		/* polar angle to start at phase1, then scalestep after phase2 */
 	unsigned	scalefrac;
@@ -525,15 +525,15 @@ typedef struct
 	uint16_t 		*clipbounds;
 } viswall_t;
 
-#define UPPER8(x) (x >> 8)
-#define LOWER8(x) (x & 0xff)
+#define UPPER8(x) ((uint8_t)((uint16_t)x >> 8))
+#define LOWER8(x) ((uint8_t)((uint16_t)x & 0xff))
 #define SETUPPER8(x, y) {\
 x &= 0x00ff; \
-x |= (y << 8); \
+x |= ((uint16_t)y << 8); \
 }
 #define SETLOWER8(x, y) {\
 x &= 0xff00; \
-x |= (y & 0xff); \
+x |= ((uint16_t)y & 0xff); \
 }
 
 typedef struct

--- a/r_local.h
+++ b/r_local.h
@@ -496,13 +496,14 @@ typedef struct
 
 	VINT     floorceilpicnum; // ceilingpicnum top word, floorpicnum bottom word (just like a ceiling and floor!)
 
+	VINT	newmiplevels; // 0 is lower, 1 is upper
+
 	int			scalestep;		/* polar angle to start at phase1, then scalestep after phase2 */
 	unsigned	scalefrac;
 	unsigned	scale2;
 
 	short	actionbits;
 	short	seglightlevel;
-	int16_t		miplevels[2];
 
 /* */
 /* filled in by bsp */

--- a/r_phase1.c
+++ b/r_phase1.c
@@ -215,14 +215,15 @@ static void R_WallEarlyPrep(rbspWork_t *rbsp, viswall_t* segl,
       f_floorheight   = front_sector->floorheight   - vd.viewz;
       f_ceilingheight = front_sector->ceilingheight - vd.viewz;
 
-      segl->floorpicnum   = flattranslation[front_sector->floorpic];
+      SETLOWER8(segl->floorceilpicnum, flattranslation[front_sector->floorpic]);
+
       if (f_ceilingpic != -1)
       {
-          segl->ceilingpicnum = flattranslation[f_ceilingpic];
+          SETUPPER8(segl->floorceilpicnum, flattranslation[f_ceilingpic]);
       }
       else
       {
-          segl->ceilingpicnum = -1;
+          SETUPPER8(segl->floorceilpicnum, (uint8_t)-1);
       }
       segl->m_texturenum = -1;
 
@@ -277,11 +278,11 @@ static void R_WallEarlyPrep(rbspWork_t *rbsp, viswall_t* segl,
          // single-sided line
 //         if (si->midtexture > 0)
          {
-            segl->t_texturenum = texturetranslation[si->midtexture];
+            SETUPPER8(segl->tb_texturenum, texturetranslation[si->midtexture]);
 
             // handle unpegging (bottom of texture at bottom, or top of texture at top)
             if(liflags & ML_DONTPEGBOTTOM)
-               t_texturemid = f_floorheight + (textures[segl->t_texturenum].height << FRACBITS);
+               t_texturemid = f_floorheight + (textures[UPPER8(segl->tb_texturenum)].height << FRACBITS);
             else
                t_texturemid = f_ceilingheight;
 
@@ -320,7 +321,7 @@ static void R_WallEarlyPrep(rbspWork_t *rbsp, viswall_t* segl,
          {
 //            if (si->bottomtexture > 0)
             {
-               segl->b_texturenum = texturetranslation[si->bottomtexture];
+               SETLOWER8(segl->tb_texturenum, texturetranslation[si->bottomtexture]);
                if(liflags & ML_DONTPEGBOTTOM)
                   b_texturemid = f_ceilingheight;
                else
@@ -339,11 +340,11 @@ static void R_WallEarlyPrep(rbspWork_t *rbsp, viswall_t* segl,
          {
 //            if (si->toptexture > 0)
             {
-               segl->t_texturenum = texturetranslation[si->toptexture];
+               SETUPPER8(segl->tb_texturenum, texturetranslation[si->toptexture]);
                if(liflags & ML_DONTPEGTOP)
                   t_texturemid = f_ceilingheight;
                else
-                  t_texturemid = b_ceilingheight + (textures[segl->t_texturenum].height << FRACBITS);
+                  t_texturemid = b_ceilingheight + (textures[UPPER8(segl->tb_texturenum)].height << FRACBITS);
 
                t_texturemid += rowoffset<<FRACBITS; // add in sidedef texture offset
 
@@ -648,8 +649,8 @@ static void R_AddLine(rbspWork_t *rbsp, seg_t *line)
    line_t *ldef;
    side_t *sidedef;
    boolean solid;
-   static sector_t ftempsec;     // killough 3/8/98: ceiling/water hack
-   static sector_t btempsec;
+//   static sector_t ftempsec;     // killough 3/8/98: ceiling/water hack
+//   static sector_t btempsec;
 
    if (line->v1 == rbsp->lastv2)
       angle1 = rbsp->lastangle2;

--- a/r_phase2.c
+++ b/r_phase2.c
@@ -179,8 +179,8 @@ static void R_SegLoop(viswall_t* segl, unsigned short* clipbounds,
 
     const fixed_t ceilingheight = segl->ceilingheight;
 
-    const int floorandlight = ((segl->seglightlevel & 0xff) << 16) | segl->floorpicnum;
-    const int ceilandlight = ((segl->seglightlevel & 0xff) << 16) | segl->ceilingpicnum;
+    const int floorandlight = ((segl->seglightlevel & 0xff) << 16) | (VINT)LOWER8(segl->floorceilpicnum);
+    const int ceilandlight = ((segl->seglightlevel & 0xff) << 16) | (VINT)UPPER8(segl->floorceilpicnum);
 
     unsigned short *flooropen = (actionbits & AC_ADDFLOOR) ? vd.visplanes[0].open : NULL;
     unsigned short *ceilopen = (actionbits & AC_ADDCEILING) ? vd.visplanes[0].open : NULL;

--- a/r_phase6.c
+++ b/r_phase6.c
@@ -474,14 +474,14 @@ void R_SegCommands(void)
 
         if (actionbits & AC_TOPTEXTURE)
         {
-            R_SetupDrawTexture(toptex, &textures[segl->t_texturenum],
+            R_SetupDrawTexture(toptex, &textures[UPPER8(segl->tb_texturenum)],
                 segl->t_texturemid, segl->t_topheight, segl->t_bottomheight);
             lseg.first--;
         }
 
         if (actionbits & AC_BOTTOMTEXTURE)
         {
-            R_SetupDrawTexture(bottomtex, &textures[segl->b_texturenum],
+            R_SetupDrawTexture(bottomtex, &textures[LOWER8(segl->tb_texturenum)],
                 segl->b_texturemid, segl->b_topheight, segl->b_bottomheight);
             lseg.last++;
         }
@@ -544,23 +544,23 @@ void Mars_Sec_R_SegCommands(void)
     {
         if (segl->actionbits & AC_TOPTEXTURE)
         {
-            texture_t* tex = &textures[segl->t_texturenum];
+            texture_t* tex = &textures[UPPER8(segl->tb_texturenum)];
             Mars_ClearCacheLines(tex->data, (sizeof(tex->data)+31)/16);
         }
         if (segl->actionbits & AC_BOTTOMTEXTURE)
         {
-            texture_t* tex = &textures[segl->b_texturenum];
+            texture_t* tex = &textures[LOWER8(segl->tb_texturenum)];
             Mars_ClearCacheLines(tex->data, (sizeof(tex->data)+31)/16);
         }
 
         if (segl->actionbits & AC_ADDFLOOR)
         {
-            flattex_t *flat = &flatpixels[segl->floorpicnum];
+            flattex_t *flat = &flatpixels[LOWER8(segl->floorceilpicnum)];
             Mars_ClearCacheLines(flat->data, (sizeof(flat->data)+31)/16);
         }
         if (segl->actionbits & AC_ADDCEILING)
         {
-            flattex_t *flat = &flatpixels[segl->ceilingpicnum];
+            flattex_t *flat = &flatpixels[UPPER8(segl->floorceilpicnum)];
             Mars_ClearCacheLines(flat->data, (sizeof(flat->data)+31)/16);
         }
     }

--- a/r_phase6.c
+++ b/r_phase6.c
@@ -493,14 +493,13 @@ void R_SegCommands(void)
         {
             if (lseg.maxmip >= MIPLEVELS)
                 lseg.maxmip = MIPLEVELS-1;
-            segl->miplevels[0] = lseg.minmip;
-            segl->miplevels[1] = lseg.maxmip;
+            SETLOWER8(segl->newmiplevels, lseg.minmip);
+            SETUPPER8(segl->newmiplevels, lseg.maxmip);
         }
         else
 #endif
         {
-            segl->miplevels[0] = 0;
-            segl->miplevels[1] = 0;
+            segl->newmiplevels = 0;
         }
 
 post_draw:

--- a/r_phase9.c
+++ b/r_phase9.c
@@ -29,7 +29,7 @@ static void R_UpdateCache(void)
    maxplanemip = 0;
    for (wall = vd.viswalls; wall < vd.lastwallcmd; wall++)
    {
-      int minmip = wall->miplevels[0], maxmip = wall->miplevels[1];
+      int minmip = LOWER8(wall->newmiplevels), maxmip = UPPER8(wall->newmiplevels);
 
       if (wall->start > wall->stop)
         continue;

--- a/r_phase9.c
+++ b/r_phase9.c
@@ -38,7 +38,7 @@ static void R_UpdateCache(void)
       {
         if (wall->actionbits & AC_TOPTEXTURE)
         {
-            texture_t* tex = &textures[wall->t_texturenum];
+            texture_t* tex = &textures[UPPER8(wall->tb_texturenum)];
 #if MIPLEVELS > 1
             int mipcount = tex->mipcount;
 #else
@@ -48,14 +48,14 @@ static void R_UpdateCache(void)
                 if (i >= mipcount)
                   break;
                 if (!R_TouchIfInTexCache(&r_texcache, tex->data[i]) && (bestmips[i] < 0)) {
-                    bestmips[i] = wall->t_texturenum;
+                    bestmips[i] = UPPER8(wall->tb_texturenum);
                 }
             }
         }
 
         if (wall->actionbits & AC_BOTTOMTEXTURE)
         {
-            texture_t* tex = &textures[wall->b_texturenum];
+            texture_t* tex = &textures[LOWER8(wall->tb_texturenum)];
 #if MIPLEVELS > 1
             int mipcount = tex->mipcount;
 #else
@@ -65,7 +65,7 @@ static void R_UpdateCache(void)
                 if (i >= mipcount)
                   break;
                 if (!R_TouchIfInTexCache(&r_texcache, tex->data[i]) && (bestmips[i] < 0)) {
-                    bestmips[i] = wall->b_texturenum;
+                    bestmips[i] = LOWER8(wall->tb_texturenum);
                 }
             }
         }
@@ -81,7 +81,7 @@ static void R_UpdateCache(void)
 
 #ifndef POTATO_MODE
       {
-        flattex_t *flat = &flatpixels[wall->floorpicnum];
+        flattex_t *flat = &flatpixels[LOWER8(wall->floorceilpicnum)];
 
         if (minplanemip < 0)
           minplanemip = 0;
@@ -90,18 +90,18 @@ static void R_UpdateCache(void)
 
         for (i = minplanemip; i <= maxplanemip; i++) {
             if (!R_TouchIfInTexCache(&r_texcache, flat->data[i]) && (bestmips[i] < 0)) {
-                bestmips[i] = numtextures+wall->floorpicnum;
+                bestmips[i] = numtextures+LOWER8(wall->floorceilpicnum);
             }
         }
 
-        if (wall->ceilingpicnum == -1) {
+        if (UPPER8(wall->floorceilpicnum) == -1) {
             continue;
         }
 
-        flat = &flatpixels[wall->ceilingpicnum];
+        flat = &flatpixels[UPPER8(wall->floorceilpicnum)];
         for (i = minplanemip; i <= maxplanemip; i++) {
             if (!R_TouchIfInTexCache(&r_texcache, flat->data[i]) && (bestmips[i] < 0)) {
-                bestmips[i] = numtextures+wall->ceilingpicnum;
+                bestmips[i] = numtextures+UPPER8(wall->floorceilpicnum);
             }
         }
       }

--- a/r_phase9.c
+++ b/r_phase9.c
@@ -94,7 +94,7 @@ static void R_UpdateCache(void)
             }
         }
 
-        if (UPPER8(wall->floorceilpicnum) == -1) {
+        if (UPPER8(wall->floorceilpicnum) == (uint8_t)-1) {
             continue;
         }
 


### PR DESCRIPTION
Instead of using byte values, which can be affected by the 32x 0-write 'feature', stuff them into VINTs.