### PR TITLE
Maintain a proportional vertical view area when using widescreen mode.

### DIFF
--- a/o_main.c
+++ b/o_main.c
@@ -433,6 +433,7 @@ void O_Control (player_t *player)
 					break;
 				case mi_anamorphic:
 					anamorphicview = slider->curval;
+					cameraTargetDistance = (anamorphicview ? CAM_DIST_ANAMORPHIC : CAM_DIST_NORMAL);
 					R_SetViewportSize(viewportNum);
 					break;
 				case mi_camerapan:
@@ -555,8 +556,10 @@ void O_Control (player_t *player)
 				{
 					switch (itemno) {
 					case mi_anamorphic:
-						if (++anamorphicview > 1)
+						if (++anamorphicview > 1) {
 							anamorphicview = 1;
+						}
+						cameraTargetDistance = CAM_DIST_ANAMORPHIC;
 						break;
 					}
 				}
@@ -565,8 +568,10 @@ void O_Control (player_t *player)
 				{
 					switch (itemno) {
 					case mi_anamorphic:
-						if (--anamorphicview < 0)
+						if (--anamorphicview < 0) {
 							anamorphicview = 0;
+						}
+						cameraTargetDistance = CAM_DIST_NORMAL;
 						break;
 					}
 				}

--- a/p_camera.c
+++ b/p_camera.c
@@ -6,6 +6,8 @@ camera_t camera;
 
 boolean invertCamera = false;
 
+fixed_t cameraTargetDistance = CAM_DIST_NORMAL;
+
 boolean PM_CheckPosition(pmovework_t *mw);
 
 static boolean P_CameraTryMove2(ptrymove_t *tm, boolean checkposonly)
@@ -37,7 +39,7 @@ static boolean P_CameraTryMove2(ptrymove_t *tm, boolean checkposonly)
       if(mw.tmceilingz - mw.tmfloorz < (tmthing->theight << FRACBITS))
          return false; // doesn't fit
       tm->floatok = true;
-      if((fixed_t)tm->tmthing->angle <= CAM_DIST && mw.tmceilingz - tmthing->z < (tmthing->theight << FRACBITS))
+      if((fixed_t)tm->tmthing->angle <= cameraTargetDistance && mw.tmceilingz - tmthing->z < (tmthing->theight << FRACBITS))
          return false; // mobj must lower itself to fit
       if(mw.tmfloorz - tmthing->z > 24*FRACUNIT)
          return false; // too big a step up
@@ -229,7 +231,7 @@ void P_MoveChaseCamera(player_t *player, camera_t *thiscam)
 	P_CameraThinker(player, thiscam);
 
 	camspeed = FRACUNIT >> 2;
-	camdist = CAM_DIST;
+	camdist = cameraTargetDistance;
 	camheight = 20 << FRACBITS;
 
    if (!player->exiting && player->stillTimer > TICRATE/2)

--- a/p_camera.h
+++ b/p_camera.h
@@ -20,11 +20,13 @@ typedef struct camera_s
 	fixed_t distFromPlayer;
 } camera_t;
 
-#define CAM_HEIGHT (20<<FRACBITS)
-#define CAM_RADIUS (20<<FRACBITS)
-#define CAM_DIST (192<<FRACBITS)
+#define CAM_HEIGHT			(20<<FRACBITS)
+#define CAM_RADIUS			(20<<FRACBITS)
+#define CAM_DIST_NORMAL		(192<<FRACBITS)
+#define CAM_DIST_ANAMORPHIC	(256<<FRACBITS)
 
 extern boolean invertCamera;
+extern fixed_t cameraTargetDistance;
 
 extern mobj_t *camBossMobj;
 extern VINT camBossMobjCounter;

--- a/p_mobj.c
+++ b/p_mobj.c
@@ -501,9 +501,9 @@ void P_SpawnPlayer (mapthing_t *mthing)
 	camera.x = mobj->x;
 	camera.y = mobj->y;
 	if (gamemapinfo.act == 3)
-		P_ThrustValues(mobj->angle, -CAM_DIST, &camera.x, &camera.y);
+		P_ThrustValues(mobj->angle, -cameraTargetDistance, &camera.x, &camera.y);
 	else
-		P_ThrustValues(mobj->angle + (ANG45 * 3), -CAM_DIST, &camera.x, &camera.y);
+		P_ThrustValues(mobj->angle + (ANG45 * 3), -cameraTargetDistance, &camera.x, &camera.y);
 	camera.x = (camera.x >> FRACBITS) << FRACBITS;
 	camera.y = (camera.y >> FRACBITS) << FRACBITS;
 	camera.subsector = I_TO_SS(R_PointInSubsector2(camera.x, camera.y));

--- a/r_main.c
+++ b/r_main.c
@@ -340,14 +340,18 @@ void R_SetViewportSize(int num)
 
 	if (anamorphicview)
 	{
-		stretch = ((FRACUNIT * 16 * height) / 180 * 28) / width;
+		//stretch = ((FRACUNIT * 16 * height) / 180 * 28) / width;
+		//stretch = FRACUNIT * 1.333333f * 2;
+		stretch = 174763;
 	}
 	else
 	{
 		/* proper screen size would be 160*100, stretched to 224 is 2.2 scale */
 		//stretch = (fixed_t)((160.0f / width) * ((float)height / 180.0f) * 2.2f * FRACUNIT);
 		//stretch = ((FRACUNIT * 16 * height) / 180 * 22) / width;
-		stretch = ((FRACUNIT * 16 * 180) / 180 * 20) / 160;
+		//stretch = ((FRACUNIT * 16 * 180) / 180 * 20) / 160;
+		//stretch = FRACUNIT * 1.000000f * 2;
+		stretch = 131072;
 	}
 	//stretchX = stretch * centerX;
 	stretchX = stretch * (160 >> 1);


### PR DESCRIPTION
Makes the following adjustments for anamorphic widescreen mode:
* Corrects the stretch ratio.
* Moves the camera farther away at a proportionate amount to the stretch.